### PR TITLE
Creación del método post para la compra de coches

### DIFF
--- a/src/AppForSEII2526.API/Controllers/PurchasesController.cs
+++ b/src/AppForSEII2526.API/Controllers/PurchasesController.cs
@@ -1,4 +1,5 @@
 ﻿using AppForSEII2526.API.DTOs.PurchaseDTO;
+using AppForSEII2526.API.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
@@ -48,6 +49,92 @@ namespace AppForSEII2526.API.Controllers
 
 
             return Ok(purchase);
+        }
+
+        [HttpPost] //operación de creación
+        [Route("[action]")] //operación de tipo acción
+        [ProducesResponseType(typeof(PurchaseDetailDTO), (int)HttpStatusCode.Created)] //devuelve OK cuando consigue meter en la base de datos el código
+        [ProducesResponseType(typeof(ValidationProblemDetails), (int)HttpStatusCode.BadRequest)] //devuelve BadRequest cuando hay un error durante la comprobación de la petición
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.Conflict)] //devuelve Conflict cuando hay un error al añadir a la base de datos
+        public async Task<ActionResult> Create_Purchase(PurchaseForCreateDTO purchaseForCreate)
+        {
+            if (purchaseForCreate.PurchaseItems.Count == 0) //compruebo que he seleccionado algún coche para comprar.
+            {
+                ModelState.AddModelError("PurchaseItems", "Error! You must include at least one movie to be purchased");
+            }
+
+            var user = _context.ApplicationUser.FirstOrDefault(au => au.UserName == purchaseForCreate.UserName); //compruebo que el usuario que compra existe en la base de datos
+            if (user == null)
+            {
+                ModelState.AddModelError("PurchaseApplicationUser", "Error! UserName is not registered");
+            }
+
+            if (ModelState.ErrorCount > 0) //si tengo algún error acumulado, devuelve BadRequest
+            {
+                return BadRequest(new ValidationProblemDetails(ModelState));
+            }
+
+            var purchaseCars = purchaseForCreate.PurchaseItems.Select(pi => pi.Model).ToList<string>();
+
+            var cars = _context.Car.Include(c => c.PurchaseItems)
+                .ThenInclude(pi => pi.Purchase)
+                .Include(c => c.Model)
+                .Where(c => purchaseCars.Contains(c.Model.Name))
+                .Select(c => new
+                {
+                    c.Id,
+                    c.Model.Name,
+                    c.QuantityForPurchasing,
+                    c.PurchasingPrice,
+                    NumberOfPurchaseItems = c.PurchaseItems.Sum(pi => pi.Quantity)
+                })
+                .ToList();
+
+            Purchase purchase = new Purchase(purchaseForCreate.DeliveryCarDealer, purchaseForCreate.PaymentMethod, DateTime.Now, new List<PurchaseItem>(), user);
+            purchase.PurchasingPrice = 0;
+
+            foreach (var item in purchaseForCreate.PurchaseItems)
+            {
+                var car = cars.FirstOrDefault(c => c.Name == item.Model);
+
+                if (car == null)
+                {
+                    ModelState.AddModelError("PurchaseItems", $"Error! The car {item.Model} is not for sale at the dealership");
+                }
+                else if ((car.NumberOfPurchaseItems + item.Quantity) > car.QuantityForPurchasing)
+                {
+                    ModelState.AddModelError("PurchaseItems", $"Error! There are not enough units available to purchase the car {item.Model}");
+                }
+                else
+                {
+                    purchase.PurchaseItems.Add(new PurchaseItem(car.Id, item.Quantity, purchase));
+                    item.PurchasingPrice = car.PurchasingPrice;
+                    purchase.PurchasingPrice += (car.PurchasingPrice * item.Quantity);
+                }
+            }
+
+            if (ModelState.ErrorCount > 0)
+            {
+                return BadRequest(new ValidationProblemDetails(ModelState));
+            }
+
+            _context.Add(purchase);
+
+            try
+            {
+                await _context.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex.Message);
+                ModelState.AddModelError("Purchase", $"Error! There was an error while saving your purchase, plese, try again later");
+                return Conflict("Error" + ex.Message);
+            }
+
+            var purchaseDetail = new PurchaseDetailDTO(purchase.ApplicationUser.Name, purchase.ApplicationUser.Surname, purchase.PurchasingDate,
+                purchase.PurchasingPrice, purchaseForCreate.PurchaseItems);
+
+            return CreatedAtAction("Get_Details_Purchase_DTO", new { id = purchase.Id }, purchaseDetail);
         }
     }
 }

--- a/src/AppForSEII2526.API/DTOs/PurchaseDTO/PurchaseForCreateDTO.cs
+++ b/src/AppForSEII2526.API/DTOs/PurchaseDTO/PurchaseForCreateDTO.cs
@@ -1,0 +1,26 @@
+﻿using AppForSEII2526.API.Models;
+
+namespace AppForSEII2526.API.DTOs.PurchaseDTO
+{
+    public class PurchaseForCreateDTO
+    {
+        public float PurchasingPrice { get; set; }
+        public string Name { get; set; }
+        public string Surname { get; set; }
+        public string UserName { get; set; }
+        public string DeliveryCarDealer { get; set; }
+        public Purchase.PurchasePaymentMethodEnum PaymentMethod { get; set; }
+        public IList<PurchaseItemDTO> PurchaseItems { get; set; }
+
+        public PurchaseForCreateDTO(float purchasingPrice, string name, string surname, string userName, string deliveryCarDealer, Purchase.PurchasePaymentMethodEnum paymentMethod, IList<PurchaseItemDTO> purchaseItems)
+        {
+            PurchasingPrice = purchasingPrice;
+            Name = name ?? throw new ArgumentNullException(nameof(Name));
+            Surname = surname ?? throw new ArgumentNullException(nameof(Surname));
+            UserName = userName ?? throw new ArgumentNullException(nameof(UserName));
+            DeliveryCarDealer = deliveryCarDealer ?? throw new ArgumentNullException(nameof(DeliveryCarDealer));
+            PaymentMethod = paymentMethod;
+            PurchaseItems = purchaseItems ?? throw new ArgumentNullException(nameof(PurchaseItems));
+        }
+    }
+}

--- a/src/AppForSEII2526.API/DTOs/PurchaseDTO/PurchaseItemDTO.cs
+++ b/src/AppForSEII2526.API/DTOs/PurchaseDTO/PurchaseItemDTO.cs
@@ -1,4 +1,6 @@
-﻿namespace AppForSEII2526.API.DTOs.PurchaseDTO
+﻿using AppForSEII2526.API.Models;
+
+namespace AppForSEII2526.API.DTOs.PurchaseDTO
 {
     public class PurchaseItemDTO
     {
@@ -6,13 +8,28 @@
         public float PurchasingPrice { get; set; }
         public string Color { get; set; }
         public int Quantity { get; set; }
+        public string Description { get; set; }
+
+        public PurchaseItemDTO()
+        {
+
+        }
 
         public PurchaseItemDTO(string model, int quantity, float purchasingPrice, string color)
         {
             Model = model;
-            Quantity = quantity;
             PurchasingPrice = purchasingPrice;
             Color = color;
+            Quantity = quantity;
+        }
+
+        public PurchaseItemDTO(string model, float purchasingPrice, string color, int quantity, string description)
+        {
+            Model = model;
+            PurchasingPrice = purchasingPrice;
+            Color = color;
+            Quantity = quantity;
+            Description = description;
         }
     }
 }

--- a/src/AppForSEII2526.API/DTOs/RentalDTO/RentalDetailDTO.cs
+++ b/src/AppForSEII2526.API/DTOs/RentalDTO/RentalDetailDTO.cs
@@ -5,14 +5,14 @@ namespace AppForSEII2526.API.DTOs.RentalDTO
     {
         public string Name { get; set; }
         public string Surname { get; set; }
-        public Rental.PaymentMethodEnum PaymentMethod { get; set; }
+        public Rental.RentalPaymentMethodEnum PaymentMethod { get; set; }
         public DateTime StartDate { get; set; }
         public DateTime EndDate { get; set; }
         public DateTime RentingDate { get; set; }
         public float TotalPrice { get; set; }
         public IList<RentalItemDTO> RentalItems { get; set; }
 
-        public RentalDetailDTO(string name, string surname, Rental.PaymentMethodEnum paymentMethod, DateTime startDate, DateTime endDate, DateTime rentingDate, float totalPrice, IList<RentalItemDTO> rentalItems)
+        public RentalDetailDTO(string name, string surname, Rental.RentalPaymentMethodEnum paymentMethod, DateTime startDate, DateTime endDate, DateTime rentingDate, float totalPrice, IList<RentalItemDTO> rentalItems)
         {
             Name = name;
             Surname = surname;

--- a/src/AppForSEII2526.API/Models/Purchase.cs
+++ b/src/AppForSEII2526.API/Models/Purchase.cs
@@ -8,7 +8,7 @@
         [Key]
         public int Id { get; set; }
 
-        public PaymentMethodEnum PaymentMethod { get; set; }
+        public PurchasePaymentMethodEnum PaymentMethod { get; set; }
 
         [DataType(System.ComponentModel.DataAnnotations.DataType.Date)]
         [DisplayFormat(DataFormatString = "{0:dd/MM/yyyy}", ApplyFormatInEditMode = true)]
@@ -21,13 +21,24 @@
         public IList<PurchaseItem> PurchaseItems { get; set; }
         public ApplicationUser ApplicationUser { get; set; }
 
-        public enum PaymentMethodEnum
+        public Purchase()
+        {
+
+        }
+
+        public Purchase(string deliveryCarDealer, PurchasePaymentMethodEnum paymentMethod, DateTime purchasingDate, IList<PurchaseItem> purchaseItems, ApplicationUser applicationUser)
+        {
+            DeliveryCarDealer = deliveryCarDealer;
+            PaymentMethod = paymentMethod;
+            PurchasingDate = purchasingDate;
+            PurchaseItems = purchaseItems;
+            ApplicationUser = applicationUser;
+        }
+
+        public enum PurchasePaymentMethodEnum
         {
             GooglePay,
             Visa
         }
-
     }
-
-    
 }

--- a/src/AppForSEII2526.API/Models/PurchaseItem.cs
+++ b/src/AppForSEII2526.API/Models/PurchaseItem.cs
@@ -11,5 +11,17 @@
 
         public int PurchaseId { get; set; }
         public Purchase Purchase { get; set; }
+
+        public PurchaseItem()
+        {
+
+        }
+
+        public PurchaseItem(int carId, int quantity, Purchase purchase)
+        {
+            CarId = carId;
+            Quantity = quantity;
+            Purchase = purchase;
+        }
     }
 }

--- a/src/AppForSEII2526.API/Models/Rental.cs
+++ b/src/AppForSEII2526.API/Models/Rental.cs
@@ -12,7 +12,7 @@
         [Key]
         public int Id { get; set; }
         
-        public PaymentMethodEnum PaymentMethod { get; set; }
+        public RentalPaymentMethodEnum PaymentMethod { get; set; }
         
         [DataType(System.ComponentModel.DataAnnotations.DataType.Date)]
         [DisplayFormat(DataFormatString = "{0:dd/MM/yyyy}", ApplyFormatInEditMode = true)]
@@ -30,7 +30,7 @@
         public IList<RentalItem> RentalItems { get; set; }
         public ApplicationUser ApplicationUser { get; set; }
 
-        public enum PaymentMethodEnum
+        public enum RentalPaymentMethodEnum
         {
             Visa,
             GooglePay,


### PR DESCRIPTION
Creación del método post para añadir la compra de un coche, además debido a que los enum de los métodos de pago de la clases "Rental" y "Purchase" tenían ambos el mismo nombre, hemos cambiado dichos nombres para que no colisionen.