### PR TITLE
Corrección campo descripción método detalles de comprar coche

### DIFF
--- a/src/AppForSEII2526.API/DTOs/PurchaseDTO/PurchaseItemDTO.cs
+++ b/src/AppForSEII2526.API/DTOs/PurchaseDTO/PurchaseItemDTO.cs
@@ -29,6 +29,7 @@ namespace AppForSEII2526.API.DTOs.PurchaseDTO
             PurchasingPrice = purchasingPrice;
             Color = color;
             Quantity = quantity;
+            Description = "description";
         }
 
         public PurchaseItemDTO(string model, float purchasingPrice, string color, int quantity, string description)


### PR DESCRIPTION
Corregido campo descripción en el método de obtener detalles de la compra de un coche, en cual debido a que no es necesario imprimir el campo "Description" se pone este con el string por defecto "description".