### PR TITLE
Comando RabbitMQ

### DIFF
--- a/src/AppForSEII2526.API/Models/ComandoRabbitMQ.txt
+++ b/src/AppForSEII2526.API/Models/ComandoRabbitMQ.txt
@@ -1,0 +1,1 @@
+docker run -d --name rabbitmq-ssdd -p 5672:5672 -p 15672:15672 rabbitmq:3-management


### PR DESCRIPTION
Se ha creado el archivo de texto el cual contiene el comando para ejecutar el RabbitMQ, dado su necesario y constante uso, en la carpeta Models